### PR TITLE
Added TOTP support through keepassxc-browser and KeeOtp plugin

### DIFF
--- a/KeePassNatMsg/Entry/EntrySearch.cs
+++ b/KeePassNatMsg/Entry/EntrySearch.cs
@@ -268,6 +268,14 @@ namespace KeePassNatMsg.Entry
                     }
                 }
 
+                // KeeOtp support through keepassxc-browser
+                // KeeOtp stores the TOTP config in a string field "otp" and provides a placeholder "{TOTP}"
+                // keepassxc-browser needs the value in a string field named "KPH: {TOTP}"
+                if (fields.Exists(p => p.Key == "otp"))
+                {
+                    fields.Add(new KeyValuePair<string, string>("KPH: {TOTP}", SprEngine.Compile("{TOTP}", ctx)));
+                }
+
                 if (fields.Count > 0)
                 {
                     var sorted = from e2 in fields orderby e2.Key ascending select e2;


### PR DESCRIPTION
First: Thanks for this great plugin! Don't know what I would without a proper KeePass Firefox integration... :)

One thing I missed, because KeePassXC and keepasscx-browser has it, is auto filling TOTPs (Timed One Time Passwords) through the browser extensions context menu.

KeePassXC supports TOTPs natively, KeePass not, so this assumes that the [KeeOtp plugin](https://keepass.info/plugins.html#keeotp) is also installed (but will not crash or anything if not).

So I don't know if you want to include this, because of the KeeOtp plugin requirement - but I find it very useful and more and more websites support 2FA with TOTPs...