### PR TITLE
Added an option to always use a defined database for KeePassNatMsg connection

### DIFF
--- a/KeePassNatMsg/ConfigOpt.cs
+++ b/KeePassNatMsg/ConfigOpt.cs
@@ -17,7 +17,7 @@ namespace KeePassNatMsg
         const string ReturnStringFieldsWithKphOnlyKey = "KeePassHttp_ReturnStringFieldsWithKphOnly";
         const string SortResultByUsernameKey = "KeePassHttp_SortResultByUsername";
         const string OverrideKeePassXcVersionKey = "KeePassNatMsg_OverrideKeePassXcVersion";
-		const string ConnectionDatabaseNameKey = "KeePassHttp_ConnectionDatabaseName";
+		const string ConnectionDatabaseHashKey = "KeePassHttp_ConnectionDatabaseHash";
 
 		public ConfigOpt(AceCustomConfig config)
         {
@@ -95,10 +95,10 @@ namespace KeePassNatMsg
             set => _config.SetString(OverrideKeePassXcVersionKey, value);
         }
 
-		public string ConnectionDatabaseName
+		public string ConnectionDatabaseHash
 		{
-			get { return _config.GetString(ConnectionDatabaseNameKey, string.Empty); }
-			set { _config.SetString(ConnectionDatabaseNameKey, value); }
+			get { return _config.GetString(ConnectionDatabaseHashKey, string.Empty); }
+			set { _config.SetString(ConnectionDatabaseHashKey, value); }
 		}
 	}
 }

--- a/KeePassNatMsg/ConfigOpt.cs
+++ b/KeePassNatMsg/ConfigOpt.cs
@@ -16,6 +16,7 @@ namespace KeePassNatMsg
         const string ReturnStringFieldsKey = "KeePassHttp_ReturnStringFields";
         const string ReturnStringFieldsWithKphOnlyKey = "KeePassHttp_ReturnStringFieldsWithKphOnly";
         const string SortResultByUsernameKey = "KeePassHttp_SortResultByUsername";
+        const string ConnectionDatabaseNameKey = "KeePassHttp_ConnectionDatabaseName";
 
         public ConfigOpt(AceCustomConfig config)
         {
@@ -85,6 +86,12 @@ namespace KeePassNatMsg
         {
             get { return _config.GetBool(SortResultByUsernameKey, true); }
             set { _config.SetBool(SortResultByUsernameKey, value); }
+        }
+
+        public string ConnectionDatabaseName
+        {
+            get { return _config.GetString(ConnectionDatabaseNameKey, string.Empty); }
+            set { _config.SetString(ConnectionDatabaseNameKey, value); }
         }
     }
 }

--- a/KeePassNatMsg/KeePassNatMsg.csproj
+++ b/KeePassNatMsg/KeePassNatMsg.csproj
@@ -40,6 +40,7 @@
       <HintPath>..\..\..\..\data\cloud.brandt.tech\apps\keepass\KeePass.exe</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Posix">
       <HintPath>lib\Mono.Posix.dll</HintPath>
     </Reference>

--- a/KeePassNatMsg/OptionsForm.Designer.cs
+++ b/KeePassNatMsg/OptionsForm.Designer.cs
@@ -373,11 +373,13 @@
 			// 
 			// comboBoxDatabases
 			// 
+			this.comboBoxDatabases.DisplayMember = "DatabaseIdentifier";
 			this.comboBoxDatabases.FormattingEnabled = true;
 			this.comboBoxDatabases.Location = new System.Drawing.Point(11, 349);
 			this.comboBoxDatabases.Name = "comboBoxDatabases";
 			this.comboBoxDatabases.Size = new System.Drawing.Size(250, 21);
 			this.comboBoxDatabases.TabIndex = 34;
+			this.comboBoxDatabases.ValueMember = "DatabaseHash";
 			// 
 			// label6
 			// 

--- a/KeePassNatMsg/OptionsForm.Designer.cs
+++ b/KeePassNatMsg/OptionsForm.Designer.cs
@@ -28,350 +28,361 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.cancelButton = new System.Windows.Forms.Button();
-            this.okButton = new System.Windows.Forms.Button();
-            this.tabControl1 = new System.Windows.Forms.TabControl();
-            this.tabPage1 = new System.Windows.Forms.TabPage();
-            this.lblProxyVersion = new System.Windows.Forms.Label();
-            this.btnInstallNativeMessaging = new System.Windows.Forms.Button();
-            this.SortByUsernameRadioButton = new System.Windows.Forms.RadioButton();
-            this.SortByTitleRadioButton = new System.Windows.Forms.RadioButton();
-            this.hideExpiredCheckbox = new System.Windows.Forms.CheckBox();
-            this.matchSchemesCheckbox = new System.Windows.Forms.CheckBox();
-            this.removePermissionsButton = new System.Windows.Forms.Button();
-            this.unlockDatabaseCheckbox = new System.Windows.Forms.CheckBox();
-            this.removeButton = new System.Windows.Forms.Button();
-            this.credMatchingCheckbox = new System.Windows.Forms.CheckBox();
-            this.credNotifyCheckbox = new System.Windows.Forms.CheckBox();
-            this.tabPage2 = new System.Windows.Forms.TabPage();
-            this.returnStringFieldsWithKphOnlyCheckBox = new System.Windows.Forms.CheckBox();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
-            this.returnStringFieldsCheckbox = new System.Windows.Forms.CheckBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.credSearchInAllOpenedDatabases = new System.Windows.Forms.CheckBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.credAllowUpdatesCheckbox = new System.Windows.Forms.CheckBox();
-            this.credAllowAccessCheckbox = new System.Windows.Forms.CheckBox();
-            this.tabControl1.SuspendLayout();
-            this.tabPage1.SuspendLayout();
-            this.tabPage2.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // cancelButton
-            // 
-            this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(313, 438);
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(88, 28);
-            this.cancelButton.TabIndex = 2;
-            this.cancelButton.Text = "&Cancel";
-            this.cancelButton.UseVisualStyleBackColor = true;
-            // 
-            // okButton
-            // 
-            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.okButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.okButton.Location = new System.Drawing.Point(219, 438);
-            this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(88, 28);
-            this.okButton.TabIndex = 1;
-            this.okButton.Text = "&Save";
-            this.okButton.UseVisualStyleBackColor = true;
-            this.okButton.Click += new System.EventHandler(this.okButton_Click);
-            // 
-            // tabControl1
-            // 
-            this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			this.cancelButton = new System.Windows.Forms.Button();
+			this.okButton = new System.Windows.Forms.Button();
+			this.tabControl1 = new System.Windows.Forms.TabControl();
+			this.tabPage1 = new System.Windows.Forms.TabPage();
+			this.lblProxyVersion = new System.Windows.Forms.Label();
+			this.btnInstallNativeMessaging = new System.Windows.Forms.Button();
+			this.SortByUsernameRadioButton = new System.Windows.Forms.RadioButton();
+			this.SortByTitleRadioButton = new System.Windows.Forms.RadioButton();
+			this.hideExpiredCheckbox = new System.Windows.Forms.CheckBox();
+			this.matchSchemesCheckbox = new System.Windows.Forms.CheckBox();
+			this.removePermissionsButton = new System.Windows.Forms.Button();
+			this.unlockDatabaseCheckbox = new System.Windows.Forms.CheckBox();
+			this.removeButton = new System.Windows.Forms.Button();
+			this.credMatchingCheckbox = new System.Windows.Forms.CheckBox();
+			this.credNotifyCheckbox = new System.Windows.Forms.CheckBox();
+			this.tabPage2 = new System.Windows.Forms.TabPage();
+			this.returnStringFieldsWithKphOnlyCheckBox = new System.Windows.Forms.CheckBox();
+			this.label4 = new System.Windows.Forms.Label();
+			this.label3 = new System.Windows.Forms.Label();
+			this.returnStringFieldsCheckbox = new System.Windows.Forms.CheckBox();
+			this.credSearchInAllOpenedDatabases = new System.Windows.Forms.CheckBox();
+			this.label1 = new System.Windows.Forms.Label();
+			this.credAllowUpdatesCheckbox = new System.Windows.Forms.CheckBox();
+			this.credAllowAccessCheckbox = new System.Windows.Forms.CheckBox();
+			this.label5 = new System.Windows.Forms.Label();
+			this.comboBoxDatabases = new System.Windows.Forms.ComboBox();
+			this.tabControl1.SuspendLayout();
+			this.tabPage1.SuspendLayout();
+			this.tabPage2.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// cancelButton
+			// 
+			this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this.cancelButton.Location = new System.Drawing.Point(313, 438);
+			this.cancelButton.Name = "cancelButton";
+			this.cancelButton.Size = new System.Drawing.Size(88, 28);
+			this.cancelButton.TabIndex = 2;
+			this.cancelButton.Text = "&Cancel";
+			this.cancelButton.UseVisualStyleBackColor = true;
+			// 
+			// okButton
+			// 
+			this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+			this.okButton.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.okButton.Location = new System.Drawing.Point(219, 438);
+			this.okButton.Name = "okButton";
+			this.okButton.Size = new System.Drawing.Size(88, 28);
+			this.okButton.TabIndex = 1;
+			this.okButton.Text = "&Save";
+			this.okButton.UseVisualStyleBackColor = true;
+			this.okButton.Click += new System.EventHandler(this.okButton_Click);
+			// 
+			// tabControl1
+			// 
+			this.tabControl1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.tabControl1.Controls.Add(this.tabPage1);
-            this.tabControl1.Controls.Add(this.tabPage2);
-            this.tabControl1.Location = new System.Drawing.Point(1, 3);
-            this.tabControl1.Name = "tabControl1";
-            this.tabControl1.SelectedIndex = 0;
-            this.tabControl1.Size = new System.Drawing.Size(410, 428);
-            this.tabControl1.TabIndex = 3;
-            // 
-            // tabPage1
-            // 
-            this.tabPage1.Controls.Add(this.lblProxyVersion);
-            this.tabPage1.Controls.Add(this.btnInstallNativeMessaging);
-            this.tabPage1.Controls.Add(this.SortByUsernameRadioButton);
-            this.tabPage1.Controls.Add(this.SortByTitleRadioButton);
-            this.tabPage1.Controls.Add(this.hideExpiredCheckbox);
-            this.tabPage1.Controls.Add(this.matchSchemesCheckbox);
-            this.tabPage1.Controls.Add(this.removePermissionsButton);
-            this.tabPage1.Controls.Add(this.unlockDatabaseCheckbox);
-            this.tabPage1.Controls.Add(this.removeButton);
-            this.tabPage1.Controls.Add(this.credMatchingCheckbox);
-            this.tabPage1.Controls.Add(this.credNotifyCheckbox);
-            this.tabPage1.Location = new System.Drawing.Point(4, 22);
-            this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(402, 402);
-            this.tabPage1.TabIndex = 0;
-            this.tabPage1.Text = "General";
-            this.tabPage1.UseVisualStyleBackColor = true;
-            // 
-            // lblProxyVersion
-            // 
-            this.lblProxyVersion.Location = new System.Drawing.Point(14, 270);
-            this.lblProxyVersion.Name = "lblProxyVersion";
-            this.lblProxyVersion.Size = new System.Drawing.Size(372, 95);
-            this.lblProxyVersion.TabIndex = 22;
-            this.lblProxyVersion.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
-            // 
-            // btnInstallNativeMessaging
-            // 
-            this.btnInstallNativeMessaging.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.tabControl1.Controls.Add(this.tabPage1);
+			this.tabControl1.Controls.Add(this.tabPage2);
+			this.tabControl1.Location = new System.Drawing.Point(1, 3);
+			this.tabControl1.Name = "tabControl1";
+			this.tabControl1.SelectedIndex = 0;
+			this.tabControl1.Size = new System.Drawing.Size(410, 428);
+			this.tabControl1.TabIndex = 3;
+			// 
+			// tabPage1
+			// 
+			this.tabPage1.Controls.Add(this.lblProxyVersion);
+			this.tabPage1.Controls.Add(this.btnInstallNativeMessaging);
+			this.tabPage1.Controls.Add(this.SortByUsernameRadioButton);
+			this.tabPage1.Controls.Add(this.SortByTitleRadioButton);
+			this.tabPage1.Controls.Add(this.hideExpiredCheckbox);
+			this.tabPage1.Controls.Add(this.matchSchemesCheckbox);
+			this.tabPage1.Controls.Add(this.removePermissionsButton);
+			this.tabPage1.Controls.Add(this.unlockDatabaseCheckbox);
+			this.tabPage1.Controls.Add(this.removeButton);
+			this.tabPage1.Controls.Add(this.credMatchingCheckbox);
+			this.tabPage1.Controls.Add(this.credNotifyCheckbox);
+			this.tabPage1.Location = new System.Drawing.Point(4, 22);
+			this.tabPage1.Name = "tabPage1";
+			this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
+			this.tabPage1.Size = new System.Drawing.Size(402, 402);
+			this.tabPage1.TabIndex = 0;
+			this.tabPage1.Text = "General";
+			this.tabPage1.UseVisualStyleBackColor = true;
+			// 
+			// lblProxyVersion
+			// 
+			this.lblProxyVersion.Location = new System.Drawing.Point(14, 270);
+			this.lblProxyVersion.Name = "lblProxyVersion";
+			this.lblProxyVersion.Size = new System.Drawing.Size(372, 95);
+			this.lblProxyVersion.TabIndex = 22;
+			this.lblProxyVersion.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
+			// 
+			// btnInstallNativeMessaging
+			// 
+			this.btnInstallNativeMessaging.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnInstallNativeMessaging.Location = new System.Drawing.Point(14, 368);
-            this.btnInstallNativeMessaging.Name = "btnInstallNativeMessaging";
-            this.btnInstallNativeMessaging.Size = new System.Drawing.Size(372, 28);
-            this.btnInstallNativeMessaging.TabIndex = 20;
-            this.btnInstallNativeMessaging.Text = "Install/Update Native Messaging Host";
-            this.btnInstallNativeMessaging.UseVisualStyleBackColor = true;
-            this.btnInstallNativeMessaging.Click += new System.EventHandler(this.btnInstallNativeMessaging_Click);
-            // 
-            // SortByUsernameRadioButton
-            // 
-            this.SortByUsernameRadioButton.AutoSize = true;
-            this.SortByUsernameRadioButton.Location = new System.Drawing.Point(7, 147);
-            this.SortByUsernameRadioButton.Name = "SortByUsernameRadioButton";
-            this.SortByUsernameRadioButton.Size = new System.Drawing.Size(171, 17);
-            this.SortByUsernameRadioButton.TabIndex = 19;
-            this.SortByUsernameRadioButton.TabStop = true;
-            this.SortByUsernameRadioButton.Text = "Sort found entries by &username";
-            this.SortByUsernameRadioButton.UseVisualStyleBackColor = true;
-            // 
-            // SortByTitleRadioButton
-            // 
-            this.SortByTitleRadioButton.AutoSize = true;
-            this.SortByTitleRadioButton.Location = new System.Drawing.Point(7, 170);
-            this.SortByTitleRadioButton.Name = "SortByTitleRadioButton";
-            this.SortByTitleRadioButton.Size = new System.Drawing.Size(141, 17);
-            this.SortByTitleRadioButton.TabIndex = 18;
-            this.SortByTitleRadioButton.TabStop = true;
-            this.SortByTitleRadioButton.Text = "Sort found entries by &title";
-            this.SortByTitleRadioButton.UseVisualStyleBackColor = true;
-            // 
-            // hideExpiredCheckbox
-            // 
-            this.hideExpiredCheckbox.AutoSize = true;
-            this.hideExpiredCheckbox.Location = new System.Drawing.Point(7, 88);
-            this.hideExpiredCheckbox.Name = "hideExpiredCheckbox";
-            this.hideExpiredCheckbox.Size = new System.Drawing.Size(152, 17);
-            this.hideExpiredCheckbox.TabIndex = 17;
-            this.hideExpiredCheckbox.Text = "Don\'t return e&xpired entries";
-            this.hideExpiredCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // matchSchemesCheckbox
-            // 
-            this.matchSchemesCheckbox.AutoSize = true;
-            this.matchSchemesCheckbox.Location = new System.Drawing.Point(7, 111);
-            this.matchSchemesCheckbox.Name = "matchSchemesCheckbox";
-            this.matchSchemesCheckbox.Size = new System.Drawing.Size(375, 30);
-            this.matchSchemesCheckbox.TabIndex = 17;
-            this.matchSchemesCheckbox.Text = "&Match URL schemes\r\nonly entries with the same scheme (http://, https://, ftp://," +
+			this.btnInstallNativeMessaging.Location = new System.Drawing.Point(14, 368);
+			this.btnInstallNativeMessaging.Name = "btnInstallNativeMessaging";
+			this.btnInstallNativeMessaging.Size = new System.Drawing.Size(372, 28);
+			this.btnInstallNativeMessaging.TabIndex = 20;
+			this.btnInstallNativeMessaging.Text = "Install/Update Native Messaging Host";
+			this.btnInstallNativeMessaging.UseVisualStyleBackColor = true;
+			this.btnInstallNativeMessaging.Click += new System.EventHandler(this.btnInstallNativeMessaging_Click);
+			// 
+			// SortByUsernameRadioButton
+			// 
+			this.SortByUsernameRadioButton.AutoSize = true;
+			this.SortByUsernameRadioButton.Location = new System.Drawing.Point(7, 147);
+			this.SortByUsernameRadioButton.Name = "SortByUsernameRadioButton";
+			this.SortByUsernameRadioButton.Size = new System.Drawing.Size(171, 17);
+			this.SortByUsernameRadioButton.TabIndex = 19;
+			this.SortByUsernameRadioButton.TabStop = true;
+			this.SortByUsernameRadioButton.Text = "Sort found entries by &username";
+			this.SortByUsernameRadioButton.UseVisualStyleBackColor = true;
+			// 
+			// SortByTitleRadioButton
+			// 
+			this.SortByTitleRadioButton.AutoSize = true;
+			this.SortByTitleRadioButton.Location = new System.Drawing.Point(7, 170);
+			this.SortByTitleRadioButton.Name = "SortByTitleRadioButton";
+			this.SortByTitleRadioButton.Size = new System.Drawing.Size(141, 17);
+			this.SortByTitleRadioButton.TabIndex = 18;
+			this.SortByTitleRadioButton.TabStop = true;
+			this.SortByTitleRadioButton.Text = "Sort found entries by &title";
+			this.SortByTitleRadioButton.UseVisualStyleBackColor = true;
+			// 
+			// hideExpiredCheckbox
+			// 
+			this.hideExpiredCheckbox.AutoSize = true;
+			this.hideExpiredCheckbox.Location = new System.Drawing.Point(7, 88);
+			this.hideExpiredCheckbox.Name = "hideExpiredCheckbox";
+			this.hideExpiredCheckbox.Size = new System.Drawing.Size(152, 17);
+			this.hideExpiredCheckbox.TabIndex = 17;
+			this.hideExpiredCheckbox.Text = "Don\'t return e&xpired entries";
+			this.hideExpiredCheckbox.UseVisualStyleBackColor = true;
+			// 
+			// matchSchemesCheckbox
+			// 
+			this.matchSchemesCheckbox.AutoSize = true;
+			this.matchSchemesCheckbox.Location = new System.Drawing.Point(7, 111);
+			this.matchSchemesCheckbox.Name = "matchSchemesCheckbox";
+			this.matchSchemesCheckbox.Size = new System.Drawing.Size(375, 30);
+			this.matchSchemesCheckbox.TabIndex = 17;
+			this.matchSchemesCheckbox.Text = "&Match URL schemes\r\nonly entries with the same scheme (http://, https://, ftp://," +
     " ...) are returned";
-            this.matchSchemesCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // removePermissionsButton
-            // 
-            this.removePermissionsButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.matchSchemesCheckbox.UseVisualStyleBackColor = true;
+			// 
+			// removePermissionsButton
+			// 
+			this.removePermissionsButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.removePermissionsButton.ImageAlign = System.Drawing.ContentAlignment.TopLeft;
-            this.removePermissionsButton.Location = new System.Drawing.Point(14, 239);
-            this.removePermissionsButton.Name = "removePermissionsButton";
-            this.removePermissionsButton.Size = new System.Drawing.Size(372, 28);
-            this.removePermissionsButton.TabIndex = 16;
-            this.removePermissionsButton.Text = "Remo&ve all stored permissions from entries in active database";
-            this.removePermissionsButton.UseVisualStyleBackColor = true;
-            this.removePermissionsButton.Click += new System.EventHandler(this.removePermissionsButton_Click);
-            // 
-            // unlockDatabaseCheckbox
-            // 
-            this.unlockDatabaseCheckbox.AutoSize = true;
-            this.unlockDatabaseCheckbox.Location = new System.Drawing.Point(7, 65);
-            this.unlockDatabaseCheckbox.Name = "unlockDatabaseCheckbox";
-            this.unlockDatabaseCheckbox.Size = new System.Drawing.Size(256, 17);
-            this.unlockDatabaseCheckbox.TabIndex = 15;
-            this.unlockDatabaseCheckbox.Text = "Re&quest for unlocking the database if it is locked";
-            this.unlockDatabaseCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // removeButton
-            // 
-            this.removeButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.removePermissionsButton.ImageAlign = System.Drawing.ContentAlignment.TopLeft;
+			this.removePermissionsButton.Location = new System.Drawing.Point(14, 239);
+			this.removePermissionsButton.Name = "removePermissionsButton";
+			this.removePermissionsButton.Size = new System.Drawing.Size(372, 28);
+			this.removePermissionsButton.TabIndex = 16;
+			this.removePermissionsButton.Text = "Remo&ve all stored permissions from entries in active database";
+			this.removePermissionsButton.UseVisualStyleBackColor = true;
+			this.removePermissionsButton.Click += new System.EventHandler(this.removePermissionsButton_Click);
+			// 
+			// unlockDatabaseCheckbox
+			// 
+			this.unlockDatabaseCheckbox.AutoSize = true;
+			this.unlockDatabaseCheckbox.Location = new System.Drawing.Point(7, 65);
+			this.unlockDatabaseCheckbox.Name = "unlockDatabaseCheckbox";
+			this.unlockDatabaseCheckbox.Size = new System.Drawing.Size(256, 17);
+			this.unlockDatabaseCheckbox.TabIndex = 15;
+			this.unlockDatabaseCheckbox.Text = "Re&quest for unlocking the database if it is locked";
+			this.unlockDatabaseCheckbox.UseVisualStyleBackColor = true;
+			// 
+			// removeButton
+			// 
+			this.removeButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.removeButton.Location = new System.Drawing.Point(14, 205);
-            this.removeButton.Name = "removeButton";
-            this.removeButton.Size = new System.Drawing.Size(372, 28);
-            this.removeButton.TabIndex = 11;
-            this.removeButton.Text = "R&emove all shared encryption-keys from active database";
-            this.removeButton.UseVisualStyleBackColor = true;
-            this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
-            // 
-            // credMatchingCheckbox
-            // 
-            this.credMatchingCheckbox.AutoSize = true;
-            this.credMatchingCheckbox.Location = new System.Drawing.Point(7, 29);
-            this.credMatchingCheckbox.Name = "credMatchingCheckbox";
-            this.credMatchingCheckbox.Size = new System.Drawing.Size(238, 30);
-            this.credMatchingCheckbox.TabIndex = 9;
-            this.credMatchingCheckbox.Text = "&Return only best matching entries for an URL\r\ninstead of all entries for the who" +
+			this.removeButton.Location = new System.Drawing.Point(14, 205);
+			this.removeButton.Name = "removeButton";
+			this.removeButton.Size = new System.Drawing.Size(372, 28);
+			this.removeButton.TabIndex = 11;
+			this.removeButton.Text = "R&emove all shared encryption-keys from active database";
+			this.removeButton.UseVisualStyleBackColor = true;
+			this.removeButton.Click += new System.EventHandler(this.removeButton_Click);
+			// 
+			// credMatchingCheckbox
+			// 
+			this.credMatchingCheckbox.AutoSize = true;
+			this.credMatchingCheckbox.Location = new System.Drawing.Point(7, 29);
+			this.credMatchingCheckbox.Name = "credMatchingCheckbox";
+			this.credMatchingCheckbox.Size = new System.Drawing.Size(238, 30);
+			this.credMatchingCheckbox.TabIndex = 9;
+			this.credMatchingCheckbox.Text = "&Return only best matching entries for an URL\r\ninstead of all entries for the who" +
     "le domain";
-            this.credMatchingCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // credNotifyCheckbox
-            // 
-            this.credNotifyCheckbox.AutoSize = true;
-            this.credNotifyCheckbox.Location = new System.Drawing.Point(7, 6);
-            this.credNotifyCheckbox.Name = "credNotifyCheckbox";
-            this.credNotifyCheckbox.Size = new System.Drawing.Size(267, 17);
-            this.credNotifyCheckbox.TabIndex = 8;
-            this.credNotifyCheckbox.Text = "Sh&ow a notification when credentials are requested";
-            this.credNotifyCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // tabPage2
-            // 
-            this.tabPage2.Controls.Add(this.returnStringFieldsWithKphOnlyCheckBox);
-            this.tabPage2.Controls.Add(this.label4);
-            this.tabPage2.Controls.Add(this.label3);
-            this.tabPage2.Controls.Add(this.returnStringFieldsCheckbox);
-            this.tabPage2.Controls.Add(this.label2);
-            this.tabPage2.Controls.Add(this.credSearchInAllOpenedDatabases);
-            this.tabPage2.Controls.Add(this.label1);
-            this.tabPage2.Controls.Add(this.credAllowUpdatesCheckbox);
-            this.tabPage2.Controls.Add(this.credAllowAccessCheckbox);
-            this.tabPage2.Location = new System.Drawing.Point(4, 22);
-            this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(402, 402);
-            this.tabPage2.TabIndex = 1;
-            this.tabPage2.Text = "Advanced";
-            this.tabPage2.UseVisualStyleBackColor = true;
-            // 
-            // returnStringFieldsWithKphOnlyCheckBox
-            // 
-            this.returnStringFieldsWithKphOnlyCheckBox.AutoSize = true;
-            this.returnStringFieldsWithKphOnlyCheckBox.Location = new System.Drawing.Point(55, 215);
-            this.returnStringFieldsWithKphOnlyCheckBox.Name = "returnStringFieldsWithKphOnlyCheckBox";
-            this.returnStringFieldsWithKphOnlyCheckBox.Size = new System.Drawing.Size(300, 30);
-            this.returnStringFieldsWithKphOnlyCheckBox.TabIndex = 31;
-            this.returnStringFieldsWithKphOnlyCheckBox.Text = "Only return advanced string fields which start with \"KPH: \"\r\n(Mind the space afte" +
+			this.credMatchingCheckbox.UseVisualStyleBackColor = true;
+			// 
+			// credNotifyCheckbox
+			// 
+			this.credNotifyCheckbox.AutoSize = true;
+			this.credNotifyCheckbox.Location = new System.Drawing.Point(7, 6);
+			this.credNotifyCheckbox.Name = "credNotifyCheckbox";
+			this.credNotifyCheckbox.Size = new System.Drawing.Size(267, 17);
+			this.credNotifyCheckbox.TabIndex = 8;
+			this.credNotifyCheckbox.Text = "Sh&ow a notification when credentials are requested";
+			this.credNotifyCheckbox.UseVisualStyleBackColor = true;
+			// 
+			// tabPage2
+			// 
+			this.tabPage2.Controls.Add(this.comboBoxDatabases);
+			this.tabPage2.Controls.Add(this.label5);
+			this.tabPage2.Controls.Add(this.returnStringFieldsWithKphOnlyCheckBox);
+			this.tabPage2.Controls.Add(this.label4);
+			this.tabPage2.Controls.Add(this.label3);
+			this.tabPage2.Controls.Add(this.returnStringFieldsCheckbox);
+			this.tabPage2.Controls.Add(this.credSearchInAllOpenedDatabases);
+			this.tabPage2.Controls.Add(this.label1);
+			this.tabPage2.Controls.Add(this.credAllowUpdatesCheckbox);
+			this.tabPage2.Controls.Add(this.credAllowAccessCheckbox);
+			this.tabPage2.Location = new System.Drawing.Point(4, 22);
+			this.tabPage2.Name = "tabPage2";
+			this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+			this.tabPage2.Size = new System.Drawing.Size(402, 402);
+			this.tabPage2.TabIndex = 1;
+			this.tabPage2.Text = "Advanced";
+			this.tabPage2.UseVisualStyleBackColor = true;
+			// 
+			// returnStringFieldsWithKphOnlyCheckBox
+			// 
+			this.returnStringFieldsWithKphOnlyCheckBox.AutoSize = true;
+			this.returnStringFieldsWithKphOnlyCheckBox.Location = new System.Drawing.Point(55, 264);
+			this.returnStringFieldsWithKphOnlyCheckBox.Name = "returnStringFieldsWithKphOnlyCheckBox";
+			this.returnStringFieldsWithKphOnlyCheckBox.Size = new System.Drawing.Size(300, 30);
+			this.returnStringFieldsWithKphOnlyCheckBox.TabIndex = 31;
+			this.returnStringFieldsWithKphOnlyCheckBox.Text = "Only return advanced string fields which start with \"KPH: \"\r\n(Mind the space afte" +
     "r KPH:)";
-            this.returnStringFieldsWithKphOnlyCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // label4
-            // 
-            this.label4.AutoSize = true;
-            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label4.Location = new System.Drawing.Point(52, 248);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(277, 26);
-            this.label4.TabIndex = 22;
-            this.label4.Text = "Automatic creates or updates are not supported\r\nfor string fields!";
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(52, 156);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(289, 52);
-            this.label3.TabIndex = 21;
-            this.label3.Text = "If there are more fields needed than username + password,\r\nnormal \"String Fields\"" +
+			this.returnStringFieldsWithKphOnlyCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// label4
+			// 
+			this.label4.AutoSize = true;
+			this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label4.Location = new System.Drawing.Point(52, 297);
+			this.label4.Name = "label4";
+			this.label4.Size = new System.Drawing.Size(277, 26);
+			this.label4.TabIndex = 22;
+			this.label4.Text = "Automatic creates or updates are not supported\r\nfor string fields!";
+			// 
+			// label3
+			// 
+			this.label3.AutoSize = true;
+			this.label3.Location = new System.Drawing.Point(52, 205);
+			this.label3.Name = "label3";
+			this.label3.Size = new System.Drawing.Size(289, 52);
+			this.label3.TabIndex = 21;
+			this.label3.Text = "If there are more fields needed than username + password,\r\nnormal \"String Fields\"" +
     " are used, which can be defined in the\r\n\"Advanced\" tab of an entry.\r\nString fiel" +
     "ds are returned in alphabetical order.";
-            // 
-            // returnStringFieldsCheckbox
-            // 
-            this.returnStringFieldsCheckbox.AutoSize = true;
-            this.returnStringFieldsCheckbox.Location = new System.Drawing.Point(7, 136);
-            this.returnStringFieldsCheckbox.Name = "returnStringFieldsCheckbox";
-            this.returnStringFieldsCheckbox.Size = new System.Drawing.Size(186, 17);
-            this.returnStringFieldsCheckbox.TabIndex = 20;
-            this.returnStringFieldsCheckbox.Text = "&Return also advanced string fields";
-            this.returnStringFieldsCheckbox.UseVisualStyleBackColor = true;
-            this.returnStringFieldsCheckbox.CheckedChanged += new System.EventHandler(this.returnStringFieldsCheckbox_CheckedChanged);
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(52, 108);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(299, 13);
-            this.label2.TabIndex = 19;
-            this.label2.Text = "Only the selected database has to be connected with a client!";
-            // 
-            // credSearchInAllOpenedDatabases
-            // 
-            this.credSearchInAllOpenedDatabases.AutoSize = true;
-            this.credSearchInAllOpenedDatabases.Location = new System.Drawing.Point(7, 88);
-            this.credSearchInAllOpenedDatabases.Name = "credSearchInAllOpenedDatabases";
-            this.credSearchInAllOpenedDatabases.Size = new System.Drawing.Size(270, 17);
-            this.credSearchInAllOpenedDatabases.TabIndex = 18;
-            this.credSearchInAllOpenedDatabases.Text = "Searc&h in all opened databases for matching entries";
-            this.credSearchInAllOpenedDatabases.UseVisualStyleBackColor = true;
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.ForeColor = System.Drawing.Color.Red;
-            this.label1.Location = new System.Drawing.Point(4, 7);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(391, 13);
-            this.label1.TabIndex = 17;
-            this.label1.Text = "Activate the following options only, if you know what you are doing!";
-            // 
-            // credAllowUpdatesCheckbox
-            // 
-            this.credAllowUpdatesCheckbox.AutoSize = true;
-            this.credAllowUpdatesCheckbox.Location = new System.Drawing.Point(6, 56);
-            this.credAllowUpdatesCheckbox.Name = "credAllowUpdatesCheckbox";
-            this.credAllowUpdatesCheckbox.Size = new System.Drawing.Size(164, 17);
-            this.credAllowUpdatesCheckbox.TabIndex = 16;
-            this.credAllowUpdatesCheckbox.Text = "Always allow &updating entries";
-            this.credAllowUpdatesCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // credAllowAccessCheckbox
-            // 
-            this.credAllowAccessCheckbox.AutoSize = true;
-            this.credAllowAccessCheckbox.Location = new System.Drawing.Point(6, 33);
-            this.credAllowAccessCheckbox.Name = "credAllowAccessCheckbox";
-            this.credAllowAccessCheckbox.Size = new System.Drawing.Size(169, 17);
-            this.credAllowAccessCheckbox.TabIndex = 15;
-            this.credAllowAccessCheckbox.Text = "Always allow &access to entries";
-            this.credAllowAccessCheckbox.UseVisualStyleBackColor = true;
-            // 
-            // OptionsForm
-            // 
-            this.AcceptButton = this.okButton;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(411, 475);
-            this.Controls.Add(this.tabControl1);
-            this.Controls.Add(this.okButton);
-            this.Controls.Add(this.cancelButton);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "OptionsForm";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "KeePassNatMsg Options";
-            this.TopMost = true;
-            this.Load += new System.EventHandler(this.OptionsForm_Load);
-            this.Shown += new System.EventHandler(this.OptionsForm_Shown);
-            this.tabControl1.ResumeLayout(false);
-            this.tabPage1.ResumeLayout(false);
-            this.tabPage1.PerformLayout();
-            this.tabPage2.ResumeLayout(false);
-            this.tabPage2.PerformLayout();
-            this.ResumeLayout(false);
+			// 
+			// returnStringFieldsCheckbox
+			// 
+			this.returnStringFieldsCheckbox.AutoSize = true;
+			this.returnStringFieldsCheckbox.Location = new System.Drawing.Point(6, 185);
+			this.returnStringFieldsCheckbox.Name = "returnStringFieldsCheckbox";
+			this.returnStringFieldsCheckbox.Size = new System.Drawing.Size(186, 17);
+			this.returnStringFieldsCheckbox.TabIndex = 20;
+			this.returnStringFieldsCheckbox.Text = "&Return also advanced string fields";
+			this.returnStringFieldsCheckbox.UseVisualStyleBackColor = true;
+			this.returnStringFieldsCheckbox.CheckedChanged += new System.EventHandler(this.returnStringFieldsCheckbox_CheckedChanged);
+			// 
+			// credSearchInAllOpenedDatabases
+			// 
+			this.credSearchInAllOpenedDatabases.AutoSize = true;
+			this.credSearchInAllOpenedDatabases.Location = new System.Drawing.Point(6, 88);
+			this.credSearchInAllOpenedDatabases.Name = "credSearchInAllOpenedDatabases";
+			this.credSearchInAllOpenedDatabases.Size = new System.Drawing.Size(270, 17);
+			this.credSearchInAllOpenedDatabases.TabIndex = 18;
+			this.credSearchInAllOpenedDatabases.Text = "Searc&h in all opened databases for matching entries";
+			this.credSearchInAllOpenedDatabases.UseVisualStyleBackColor = true;
+			// 
+			// label1
+			// 
+			this.label1.AutoSize = true;
+			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label1.ForeColor = System.Drawing.Color.Red;
+			this.label1.Location = new System.Drawing.Point(6, 7);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(391, 13);
+			this.label1.TabIndex = 17;
+			this.label1.Text = "Activate the following options only, if you know what you are doing!";
+			// 
+			// credAllowUpdatesCheckbox
+			// 
+			this.credAllowUpdatesCheckbox.AutoSize = true;
+			this.credAllowUpdatesCheckbox.Location = new System.Drawing.Point(6, 56);
+			this.credAllowUpdatesCheckbox.Name = "credAllowUpdatesCheckbox";
+			this.credAllowUpdatesCheckbox.Size = new System.Drawing.Size(164, 17);
+			this.credAllowUpdatesCheckbox.TabIndex = 16;
+			this.credAllowUpdatesCheckbox.Text = "Always allow &updating entries";
+			this.credAllowUpdatesCheckbox.UseVisualStyleBackColor = true;
+			// 
+			// credAllowAccessCheckbox
+			// 
+			this.credAllowAccessCheckbox.AutoSize = true;
+			this.credAllowAccessCheckbox.Location = new System.Drawing.Point(6, 33);
+			this.credAllowAccessCheckbox.Name = "credAllowAccessCheckbox";
+			this.credAllowAccessCheckbox.Size = new System.Drawing.Size(169, 17);
+			this.credAllowAccessCheckbox.TabIndex = 15;
+			this.credAllowAccessCheckbox.Text = "Always allow &access to entries";
+			this.credAllowAccessCheckbox.UseVisualStyleBackColor = true;
+			// 
+			// label5
+			// 
+			this.label5.AutoSize = true;
+			this.label5.Location = new System.Drawing.Point(6, 122);
+			this.label5.Name = "label5";
+			this.label5.Size = new System.Drawing.Size(281, 26);
+			this.label5.TabIndex = 32;
+			this.label5.Text = "Always use this database for KeepassNatMsg connection\r\n(leave empty to always use" +
+    " the current selected database)";
+			// 
+			// comboBoxDatabases
+			// 
+			this.comboBoxDatabases.FormattingEnabled = true;
+			this.comboBoxDatabases.Location = new System.Drawing.Point(6, 151);
+			this.comboBoxDatabases.Name = "comboBoxDatabases";
+			this.comboBoxDatabases.Size = new System.Drawing.Size(270, 21);
+			this.comboBoxDatabases.TabIndex = 33;
+			// 
+			// OptionsForm
+			// 
+			this.AcceptButton = this.okButton;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.CancelButton = this.cancelButton;
+			this.ClientSize = new System.Drawing.Size(411, 475);
+			this.Controls.Add(this.tabControl1);
+			this.Controls.Add(this.okButton);
+			this.Controls.Add(this.cancelButton);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "OptionsForm";
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			this.Text = "KeePassNatMsg Options";
+			this.TopMost = true;
+			this.Load += new System.EventHandler(this.OptionsForm_Load);
+			this.Shown += new System.EventHandler(this.OptionsForm_Shown);
+			this.tabControl1.ResumeLayout(false);
+			this.tabPage1.ResumeLayout(false);
+			this.tabPage1.PerformLayout();
+			this.tabPage2.ResumeLayout(false);
+			this.tabPage2.PerformLayout();
+			this.ResumeLayout(false);
 
         }
 
@@ -393,7 +404,6 @@
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.CheckBox credAllowUpdatesCheckbox;
         private System.Windows.Forms.CheckBox credAllowAccessCheckbox;
-        private System.Windows.Forms.Label label2;
         private System.Windows.Forms.CheckBox returnStringFieldsCheckbox;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Label label4;
@@ -402,5 +412,7 @@
         private System.Windows.Forms.CheckBox returnStringFieldsWithKphOnlyCheckBox;
         private System.Windows.Forms.Button btnInstallNativeMessaging;
         private System.Windows.Forms.Label lblProxyVersion;
-    }
+		private System.Windows.Forms.ComboBox comboBoxDatabases;
+		private System.Windows.Forms.Label label5;
+	}
 }

--- a/KeePassNatMsg/OptionsForm.cs
+++ b/KeePassNatMsg/OptionsForm.cs
@@ -47,6 +47,9 @@ namespace KeePassNatMsg
             SortByTitleRadioButton.Checked = !_config.SortResultByUsername;
 
             this.returnStringFieldsCheckbox_CheckedChanged(null, EventArgs.Empty);
+
+            InitDatabasesDropdown();
+            this.comboBoxDatabases.Text = _config.ConnectionDatabaseName;
         }
 
         private void okButton_Click(object sender, EventArgs e)
@@ -62,6 +65,7 @@ namespace KeePassNatMsg
             _config.ReturnStringFields = returnStringFieldsCheckbox.Checked;
             _config.ReturnStringFieldsWithKphOnly = returnStringFieldsWithKphOnlyCheckBox.Checked;
             _config.SortResultByUsername = SortByUsernameRadioButton.Checked;
+            _config.ConnectionDatabaseName = comboBoxDatabases.Text;
             if (_restartRequired)
             {
                 MessageBox.Show(
@@ -285,6 +289,14 @@ namespace KeePassNatMsg
             lst.Add($"Proxy: {proxyDisplay}{latestVersionDisplay}");
 
             lblProxyVersion.Text = string.Join(Environment.NewLine, lst);
+        }
+
+        private void InitDatabasesDropdown()
+        {
+            foreach (var item in KeePass.Program.MainForm.DocumentManager.Documents)
+            {
+                comboBoxDatabases.Items.Add(item.Database.Name);
+            }
         }
     }
 }

--- a/KeePassNatMsg/OptionsForm.cs
+++ b/KeePassNatMsg/OptionsForm.cs
@@ -73,7 +73,7 @@ namespace KeePassNatMsg
             _config.ReturnStringFieldsWithKphOnly = returnStringFieldsWithKphOnlyCheckBox.Checked;
             _config.SortResultByUsername = SortByUsernameRadioButton.Checked;
             _config.OverrideKeePassXcVersion = txtKPXCVerOverride.Text;
-			_config.ConnectionDatabaseHash = (comboBoxDatabases.SelectedItem as dynamic).DatabaseHash;
+			_config.ConnectionDatabaseHash = (comboBoxDatabases.SelectedItem as dynamic)?.DatabaseHash;
 			if (_restartRequired)
             {
                 MessageBox.Show(

--- a/KeePassNatMsg/OptionsForm.cs
+++ b/KeePassNatMsg/OptionsForm.cs
@@ -50,7 +50,13 @@ namespace KeePassNatMsg
             this.returnStringFieldsCheckbox_CheckedChanged(null, EventArgs.Empty);
 
 			InitDatabasesDropdown();
-			this.comboBoxDatabases.Text = _config.ConnectionDatabaseName;
+			foreach (dynamic item in comboBoxDatabases.Items)
+			{
+				if (item.DatabaseHash == _config.ConnectionDatabaseHash)
+				{
+					comboBoxDatabases.SelectedItem = item;
+				}
+			}
 		}
 
         private void okButton_Click(object sender, EventArgs e)
@@ -67,7 +73,7 @@ namespace KeePassNatMsg
             _config.ReturnStringFieldsWithKphOnly = returnStringFieldsWithKphOnlyCheckBox.Checked;
             _config.SortResultByUsername = SortByUsernameRadioButton.Checked;
             _config.OverrideKeePassXcVersion = txtKPXCVerOverride.Text;
-			_config.ConnectionDatabaseName = comboBoxDatabases.Text;
+			_config.ConnectionDatabaseHash = (comboBoxDatabases.SelectedItem as dynamic).DatabaseHash;
 			if (_restartRequired)
             {
                 MessageBox.Show(
@@ -297,7 +303,13 @@ namespace KeePassNatMsg
 		{
 			foreach (var item in KeePass.Program.MainForm.DocumentManager.Documents)
 			{
-				comboBoxDatabases.Items.Add(item.Database.Name);
+				var dbIdentifier = item.Database.Name;
+				if (string.IsNullOrEmpty(dbIdentifier))
+				{
+					dbIdentifier = item.Database.IOConnectionInfo.Path;
+				}
+
+				comboBoxDatabases.Items.Add(new { DatabaseIdentifier = dbIdentifier, DatabaseHash = KeePassNatMsgExt.ExtInstance.GetDbHash(item.Database)});
 			}
 		}
 	}


### PR DESCRIPTION
Hi (again :)),

I've had the following problem:
I use KeePass always with multiple databases, but only the "first" is connected via KeePassNatMsg - it works as intended that also entries from the other open databases are returned, but only if the currently selected database is the connected one (as stated in the options dialog).

But that always gives the problem that when I did something in one of the other open databases and just minimized KeePass, so that the currently selected database is not the connected one, the connection does not work anymore.

So I added a config option to always use a defined database (by name) for the KeePassNatMsg connection, regardless of the currently selected one. When the config option is not set or contains an invalid / not currently opened database name, it uses the currently selected database - as of now.

This is how the changed options dialog looks like:

![grafik](https://user-images.githubusercontent.com/2161815/59517154-34f8d380-8ec3-11e9-873c-8d06f312c5cd.png)