### PR TITLE
Update reported KeePassXC version to 2.5.4

### DIFF
--- a/KeePassNatMsg/KeePassNatMsgExt.cs
+++ b/KeePassNatMsg/KeePassNatMsgExt.cs
@@ -51,7 +51,7 @@ namespace KeePassNatMsg
         public const string AssociateKeyPrefix = "Public Key: ";
         private const string PipeName = "kpxc_server";
 
-        private static readonly Version KeePassXcVersion = new Version(2, 4, 3);
+        private static readonly Version KeePassXcVersion = new Version(2, 5, 4);
 
         private IListener _listener;
 


### PR DESCRIPTION
KeePassXC-Browser complains about old KeePassXC version again. KeePassXC is currently at 2.5.4, so this updates default reported KeePassXC version to that.