### PR TITLE
Add ChromeKeePass to the list of allowed origins for native messaging

### DIFF
--- a/KeePassNatMsg/Properties/Resources.resx
+++ b/KeePassNatMsg/Properties/Resources.resx
@@ -124,6 +124,7 @@
   "path" : "{0}",
   "type": "stdio",
   "allowed_origins": [
+    "chrome-extension://dphoaaiomekdhacmfoblfblmncpnbahm/",
     "chrome-extension://iopaggbpplllidnfmcghoonnokmjoicf/",
     "chrome-extension://oboonakemofpalcgghocfoadofidjkkk/",
     "chrome-extension://pdffhmdngciaglkoonimfcmckehcpafo/"
@@ -141,6 +142,7 @@
   "path" : "{0}",
   "type": "stdio",
   "allowed_origins": [
+    "chrome-extension://dphoaaiomekdhacmfoblfblmncpnbahm/",
     "chrome-extension://iopaggbpplllidnfmcghoonnokmjoicf/",
     "chrome-extension://oboonakemofpalcgghocfoadofidjkkk/",
     "chrome-extension://pdffhmdngciaglkoonimfcmckehcpafo/"


### PR DESCRIPTION
[ChromeKeePass](https://github.com/RoelVB/ChromeKeePass) is adding support for communication with KeePass via KeePassNatMsg in https://github.com/RoelVB/ChromeKeePass/pull/93
In order for this to work, the extension needs to be added to the allowed hosts of the native messaging configuration file, otherwise Chrome and Edge will not open the native messaging channel.

The extension can be found in the [Chrome web store](https://chrome.google.com/webstore/detail/chromekeepass/dphoaaiomekdhacmfoblfblmncpnbahm) (although the latest version there doesn't have the native messaging support yet).

I don't have a setup to compile these changes at the moment, so I can't actually verify that this works, but it seemed like a simple enough change. I added these lines to the extracted files on my system manually and verified that ChromeKeePass was able to communicate with KeePassNatMsg.