### PR TITLE
Fix compatibility between "search string fields for URL" and "Match URL schemes"

### DIFF
--- a/KeePassNatMsg/Entry/EntrySearch.cs
+++ b/KeePassNatMsg/Entry/EntrySearch.cs
@@ -387,7 +387,7 @@ namespace KeePassNatMsg.Entry
             var formHost = hostUri.Host;
             var searchHost = hostUri.Host;
             var origSearchHost = hostUri.Host;
-            var schemeHost = hostUri.Scheme;
+            var searchScheme = hostUri.Scheme;
 
             List<PwDatabase> listDatabases = new List<PwDatabase>();
 
@@ -419,7 +419,7 @@ namespace KeePassNatMsg.Entry
                 {
                     if (configOpt.MatchSchemes)
                     {
-                        parms.SearchString = string.Format("^{0}$|{1}://{0}/?", searchHost, schemeHost);
+                        parms.SearchString = string.Format("^{0}$|{1}://{0}/?", searchHost, searchScheme);
                     }
                     else
                     {


### PR DESCRIPTION
When "Search string fields for URL" is checked, the option "Match URL schemes" block some valid entries.
The solution is to change the search method to validate the scheme if necessary beforehand.

Issue https://github.com/smorks/keepassnatmsg/issues/112