### PR TITLE
Sort access control list

### DIFF
--- a/KeePassNatMsg/AccessControlForm.Designer.cs
+++ b/KeePassNatMsg/AccessControlForm.Designer.cs
@@ -68,6 +68,7 @@
             this.EntriesBox.Location = new System.Drawing.Point(12, 12);
             this.EntriesBox.Name = "EntriesBox";
             this.EntriesBox.Size = new System.Drawing.Size(320, 108);
+            this.EntriesBox.Sorted = true;
             this.EntriesBox.TabIndex = 0;
             // 
             // RememberCheck


### PR DESCRIPTION
It's easier to read when you have several items in the access control popup to have them in alphabetical order.